### PR TITLE
typescript declaration file fixed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,18 +1,16 @@
-import {Middleware, Dispatch} from "redux";
-
+import { Middleware, Dispatch } from "redux";
 
 export type ThunkAction<R, S, E> = (dispatch: Dispatch<S>, getState: () => S,
-                                    extraArgument: E) => R;
+    extraArgument: E) => R;
 
 declare module "redux" {
-  export interface Dispatch<S> {
-    <R, E>(asyncAction: ThunkAction<R, S, E>): R;
-  }
+    export interface Dispatch<S> {
+        <R, E>(asyncAction: ThunkAction<R, S, E>): R;
+    }
 }
 
+declare type ErrorHandler = (error: any, state: any, action: any, dispatch: any) => void;
 
-declare const thunk: Middleware & {
-  withExtraArgument(extraArgument: any): Middleware;
-};
+declare const createThunkMiddleware: (errorHandler: ErrorHandler, extraArgument: any) => Middleware;
 
-export default thunk;
+export default createThunkMiddleware;

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,6 @@ declare module "redux" {
 
 declare type ErrorHandler = (error: any, state: any, action: any, dispatch: any) => void;
 
-declare const createThunkMiddleware: (errorHandler: ErrorHandler, extraArgument: any) => Middleware;
+declare const createThunkMiddleware: (errorHandler: ErrorHandler, extraArgument?: any) => Middleware;
 
 export default createThunkMiddleware;


### PR DESCRIPTION
The index.d.ts file was broken - I think it was copied from redux-thunk and after you made a new parameter in fabric method to create middleware you did not changed d.ts file. So is's now possible to use your lib with typescript but without these changes I couldn't